### PR TITLE
Use /.dockerenv as a fallback mechanism

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ var isDocker;
 function check() {
 	try {
 		fs.statSync('/.dockerinit');
+    fs.statSync('/.dockerenv');
 		return true;
 	} catch (err) {
 		return false;


### PR DESCRIPTION
On my machine, /.dockerinit was not present. Since I'm using a fresh install from
[brew](http://brew.sh/), I suspect I'm not the only one with this problem. This patch
updates is-docker to check for a /.dockerenv file if /.dockerinit is not found.