### PR TITLE
fix: check /.dockerenv or cgroup setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,3 @@ language: node_js
 node_js:
   - '6'
   - '4'
-  - '0.12'
-  - '0.10'

--- a/index.js
+++ b/index.js
@@ -1,15 +1,27 @@
 'use strict';
 var fs = require('fs');
+
 var isDocker;
 
-function check() {
+function hasDockerEnv() {
 	try {
-		fs.statSync('/.dockerinit');
 		fs.statSync('/.dockerenv');
 		return true;
 	} catch (err) {
 		return false;
 	}
+}
+
+function hasDockerCGroup() {
+	try {
+		return fs.readFileSync('/proc/self/cgroup', 'utf8').indexOf('docker') !== -1;
+	} catch (err) {
+		return false;
+	}
+}
+
+function check() {
+	return hasDockerEnv() || hasDockerCGroup();
 }
 
 module.exports = function () {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "sindresorhus.com"
   },
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=4"
   },
   "scripts": {
     "test": "xo && ava"

--- a/test.js
+++ b/test.js
@@ -3,12 +3,28 @@ import path from 'path';
 import test from 'ava';
 import sinon from 'sinon';
 
-test('inside a Docker container', t => {
+test('inside a Docker container (.dockerenv test)', t => {
 	delete require.cache[path.join(__dirname, 'index.js')];
 	const isDocker = require('./');
 	fs.statSync = sinon.stub(fs, 'statSync');
-	fs.statSync.withArgs('/.dockerinit').returns({});
+	fs.statSync.withArgs('/.dockerenv').returns({});
 	t.true(isDocker());
+	fs.statSync.restore();
+});
+
+test('inside a Docker container (cgroup test)', t => {
+	delete require.cache[path.join(__dirname, 'index.js')];
+	const isDocker = require('./');
+
+	fs.statSync = sinon.stub(fs, 'statSync');
+	fs.statSync.withArgs('/.dockerenv').throws('ENOENT, no such file or directory \'/.dockerinit\'');
+
+	fs.readFileSync = sinon.stub(fs, 'readFileSync');
+	fs.readFileSync.withArgs('/proc/self/cgroup', 'utf8').returns('xxx docker yyyy');
+
+	t.true(isDocker());
+
+	fs.readFileSync.restore();
 	fs.statSync.restore();
 });
 
@@ -16,7 +32,7 @@ test('not inside a Docker container', t => {
 	delete require.cache[path.join(__dirname, 'index.js')];
 	const isDocker = require('./');
 	fs.statSync = sinon.stub(fs, 'statSync');
-	fs.statSync.withArgs('/.dockerinit').throws('ENOENT, no such file or directory \'/.dockerinit\'');
+	fs.statSync.withArgs('/.dockerenv').throws('ENOENT, no such file or directory \'/.dockerinit\'');
 	t.false(isDocker());
 	fs.statSync.restore();
 });


### PR DESCRIPTION
docker removed /.dockerinit file and /.dockerenv is kind of deprecated.
This change therefore checks for /.dockerenv and the cgroup

See:
https://github.com/docker/docker/issues/18355
https://github.com/docker/docker/pull/19490