### PR TITLE
Update actions/setup-node to v2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
           - 8
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install


### PR DESCRIPTION
## Changes:

- Update `actions/setup-node` to `v2`

## Context:

`actions/setup-node` is now stable at version `v2`.
See the release notes here: https://github.com/actions/setup-node/releases