### PR TITLE
Checking for .containerenv file

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,15 @@ function hasDockerEnv() {
 	}
 }
 
+function hasContainerEnv() {
+	try {
+		fs.statSync('/run/.containerenv');
+		return true;
+	} catch {
+		return false;
+	}
+}
+
 function hasDockerCGroup() {
 	try {
 		return fs.readFileSync('/proc/self/cgroup', 'utf8').includes('docker');
@@ -22,7 +31,7 @@ function hasDockerCGroup() {
 export default function isDocker() {
 	// TODO: Use `??=` when targeting Node.js 16.
 	if (isDockerCached === undefined) {
-		isDockerCached = hasDockerEnv() || hasDockerCGroup();
+		isDockerCached = hasDockerEnv() || hasContainerEnv() || hasDockerCGroup();
 	}
 
 	return isDockerCached;


### PR DESCRIPTION
This would allow us to check whether we are running in podman containers as well. The .containerenv file is the standard way to check if we are running in one of these containers as per: https://docs.podman.io/en/latest/markdown/podman-run.1.html