### PR TITLE
Detect docker during `docker build`

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,8 @@ function hasDockerCGroup() {
 
 function hasDockerMountInfo() {
 	try {
-		return fs.readFileSync('/proc/self/mountinfo', 'utf8').includes('/docker/containers/');
+		const mountinfo = fs.readFileSync('/proc/self/mountinfo', 'utf8');
+		return mountinfo.includes('/docker/containers/') || mountinfo.includes('/docker/buildkit/');
 	} catch {
 		return false;
 	}


### PR DESCRIPTION
I'm on macOS `26.1` and have installed docker through Docker Desktop `4.41.2`.

Here is a simple demo of `is-docker` not recognizing docker during the build process:
```Dockerfile
FROM node:22.20.0-alpine3.22

RUN (npx -y is-docker && echo "Running in docker") || echo "Not running in docker"
RUN cat /proc/self/mountinfo
```

```shell
$ docker build --platform=linux/amd64 --progress=plain .
#0 building with "desktop-linux" instance using docker driver

#1 [internal] load build definition from Dockerfile
#1 transferring dockerfile: 182B done
#1 DONE 0.0s

#2 [internal] load metadata for docker.io/library/node:22.20.0-alpine3.22
#2 DONE 1.8s

#3 [internal] load .dockerignore
#3 transferring context: 2B done
#3 DONE 0.0s

#4 [1/3] FROM docker.io/library/node:22.20.0-alpine3.22@sha256:dbcedd8aeab47fbc0f4dd4bffa55b7c3c729a707875968d467aaaea42d6225af
#4 resolve docker.io/library/node:22.20.0-alpine3.22@sha256:dbcedd8aeab47fbc0f4dd4bffa55b7c3c729a707875968d467aaaea42d6225af done
#4 CACHED

#5 [2/3] RUN (npx -y is-docker && echo "Running in docker") || echo "Not running in docker"
#5 2.235 npm notice
#5 2.235 npm notice New major version of npm available! 10.9.3 -> 11.6.4
#5 2.235 npm notice Changelog: https://github.com/npm/cli/releases/tag/v11.6.4
#5 2.235 npm notice To update run: npm install -g npm@11.6.4
#5 2.235 npm notice
#5 2.352 Not running in docker
#5 DONE 2.4s

#6 [3/3] RUN cat /proc/self/mountinfo
#6 0.121 139 85 0:63 / / rw,relatime - overlay overlay rw,lowerdir=/var/lib/desktop-containerd/daemon/io.containerd.snapshotter.v1.overlayfs/snapshots/430/fs:/var/lib/desktop-containerd/daemon/io.containerd.snapshotter.v1.overlayfs/snapshots/409/fs:/var/lib/desktop-containerd/daemon/io.containerd.snapshotter.v1.overlayfs/snapshots/408/fs:/var/lib/desktop-containerd/daemon/io.containerd.snapshotter.v1.overlayfs/snapshots/407/fs:/var/lib/desktop-containerd/daemon/io.containerd.snapshotter.v1.overlayfs/snapshots/384/fs,upperdir=/var/lib/desktop-containerd/daemon/io.containerd.snapshotter.v1.overlayfs/snapshots/431/fs,workdir=/var/lib/desktop-containerd/daemon/io.containerd.snapshotter.v1.overlayfs/snapshots/431/work,uuid=on
#6 0.121 141 139 0:71 / /proc rw,nosuid,nodev,noexec,relatime - proc proc rw
#6 0.121 142 139 0:72 / /dev rw,nosuid - tmpfs tmpfs rw,size=65536k,mode=755
#6 0.121 143 142 0:73 / /dev/pts rw,nosuid,noexec,relatime - devpts devpts rw,gid=5,mode=620,ptmxmode=666
#6 0.121 144 142 0:74 / /dev/shm rw,nosuid,nodev,noexec,relatime - tmpfs shm rw,size=65536k
#6 0.121 145 142 0:69 / /dev/mqueue rw,nosuid,nodev,noexec,relatime - mqueue mqueue rw
#6 0.121 146 139 0:75 / /sys ro,nosuid,nodev,noexec,relatime - sysfs sysfs ro
#6 0.121 147 139 254:1 /docker/buildkit/executor/resolv.conf /etc/resolv.conf ro,nosuid,nodev,noexec,relatime master:1 - ext4 /dev/vda1 rw,discard
#6 0.121 149 139 254:1 /docker/buildkit/executor/hosts.dy4k39fasooyn3mpdya9ezl5x /etc/hosts ro,nosuid,nodev,noexec,relatime master:1 - ext4 /dev/vda1 rw,discard
#6 0.121 150 146 0:39 / /sys/fs/cgroup ro,nosuid,nodev,noexec,relatime - cgroup2 cgroup rw
#6 0.121 86 141 0:71 /bus /proc/bus ro,nosuid,nodev,noexec,relatime - proc proc rw
#6 0.121 87 141 0:71 /fs /proc/fs ro,nosuid,nodev,noexec,relatime - proc proc rw
#6 0.121 88 141 0:71 /irq /proc/irq ro,nosuid,nodev,noexec,relatime - proc proc rw
#6 0.121 89 141 0:71 /sys /proc/sys ro,nosuid,nodev,noexec,relatime - proc proc rw
#6 0.121 90 141 0:71 /sysrq-trigger /proc/sysrq-trigger ro,nosuid,nodev,noexec,relatime - proc proc rw
#6 0.121 91 141 0:72 /null /proc/kcore rw,nosuid - tmpfs tmpfs rw,size=65536k,mode=755
#6 0.121 92 141 0:72 /null /proc/keys rw,nosuid - tmpfs tmpfs rw,size=65536k,mode=755
#6 0.121 93 141 0:72 /null /proc/timer_list rw,nosuid - tmpfs tmpfs rw,size=65536k,mode=755
#6 0.121 94 146 0:76 / /sys/firmware ro,relatime - tmpfs tmpfs ro
#6 0.121 95 141 0:77 / /proc/scsi ro,relatime - tmpfs tmpfs ro
#6 DONE 0.1s
```

As we can see `/docker/containers/` is not present, but `/docker/buildkit/` is. Seems to me - at least at surface level - unlikely to pass outside of docker but to better detect the build process, at least on my platform